### PR TITLE
use the distribution protocol to determine account id and region

### DIFF
--- a/ecr-login/ecr.go
+++ b/ecr-login/ecr.go
@@ -17,6 +17,9 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/http"
+	"net/url"
+	"strings"
 
 	"github.com/sirupsen/logrus"
 
@@ -29,14 +32,27 @@ var notImplemented = errors.New("not implemented")
 type ECRHelper struct {
 	clientFactory api.ClientFactory
 	logger        *logrus.Logger
+	http          HTTPClient
 }
 
 type Option func(*ECRHelper)
+
+type HTTPClient interface {
+	Do(req *http.Request) (*http.Response, error)
+}
 
 // WithClientFactory sets the ClientFactory used to make API requests.
 func WithClientFactory(clientFactory api.ClientFactory) Option {
 	return func(e *ECRHelper) {
 		e.clientFactory = clientFactory
+	}
+}
+
+// WithHTTPClient sets the HTTPClient used for the registry
+// distribution protocol.
+func WithHTTPClient(httpClient HTTPClient) Option {
+	return func(e *ECRHelper) {
+		e.http = httpClient
 	}
 }
 
@@ -59,6 +75,7 @@ func NewECRHelper(opts ...Option) *ECRHelper {
 	e := &ECRHelper{
 		clientFactory: api.DefaultClientFactory{},
 		logger:        logrus.StandardLogger(),
+		http:          http.DefaultClient,
 	}
 	for _, o := range opts {
 		o(e)
@@ -83,11 +100,32 @@ func (ECRHelper) Delete(serverURL string) error {
 func (self ECRHelper) Get(serverURL string) (string, string, error) {
 	registry, err := api.ExtractRegistry(serverURL)
 	if err != nil {
+		// If the serverURL doesn't match the expected pattern,
+		// use the distribution protocol to check if it advertises
+		// an ECR auth realm.
+		realm := self.lookupDistributionAuthRealm(serverURL)
+		if realm == "" {
+			self.logger.
+				WithError(err).
+				WithField("serverURL", serverURL).
+				Error("Error parsing the serverURL")
+			return "", "", credentials.NewErrCredentialsNotFound()
+		}
+
 		self.logger.
-			WithError(err).
 			WithField("serverURL", serverURL).
-			Error("Error parsing the serverURL")
-		return "", "", credentials.NewErrCredentialsNotFound()
+			WithField("realm", realm).
+			Info("Discovered registry auth realm")
+
+		registry, err = api.ExtractRegistry(realm)
+		if err != nil {
+			self.logger.
+				WithError(err).
+				WithField("serverURL", realm).
+				Error("Error parsing the auth realm")
+			return "", "", credentials.NewErrCredentialsNotFound()
+		}
+		serverURL = realm
 	}
 
 	var client api.Client
@@ -126,4 +164,63 @@ func (self ECRHelper) List() (map[string]string, error) {
 		result[serverURL] = auth.Username
 	}
 	return result, nil
+}
+
+// Check to see if the serverURL advertises a place to
+// go for auth.
+func (self ECRHelper) lookupDistributionAuthRealm(serverURL string) string {
+	req, err := http.NewRequest("HEAD",
+		fmt.Sprintf("https://%s/v2", serverURL), nil)
+	if err != nil {
+		return ""
+	}
+
+	resp, err := self.http.Do(req)
+	if err != nil {
+		return ""
+	}
+
+	authHeader := parseWWWAuthenticateHeader(
+		resp.Header.Get("Www-Authenticate"))
+	if authHeader == nil {
+		return ""
+	}
+
+	realm := authHeader.params["realm"]
+	if realm == "" {
+		return ""
+	}
+
+	realmURL, err := url.Parse(realm)
+	if err != nil {
+		return ""
+	}
+	return realmURL.Host
+}
+
+type authHeader struct {
+	authType string
+	params   map[string]string
+}
+
+// Expected format:
+// Basic realm="https://0123456789.dkr.ecr.us-east-1.amazonaws.com/",service="ecr.amazonaws.com"
+func parseWWWAuthenticateHeader(header string) *authHeader {
+	parts := strings.SplitN(header, " ", 2)
+	if len(parts) < 2 {
+		return nil
+	}
+	result := &authHeader{
+		authType: parts[0],
+		params:   make(map[string]string),
+	}
+	pairs := strings.Split(parts[1], ",")
+	for _, pair := range pairs {
+		kv := strings.SplitN(pair, "=", 2)
+		if len(kv) < 2 {
+			continue
+		}
+		result.params[strings.Trim(kv[0], " \"")] = strings.Trim(kv[1], " \"")
+	}
+	return result
 }


### PR DESCRIPTION
this allows ecr-login to determine the correct
ECR instance, even when ECR is behind a custom domain.

Fixes https://github.com/awslabs/amazon-ecr-credential-helper/issues/94

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
